### PR TITLE
Board Reset BugFix

### DIFF
--- a/src/CUSBCommunication.cpp
+++ b/src/CUSBCommunication.cpp
@@ -34,7 +34,6 @@ CUSBCommunication::CUSBCommunication(string device) : transfer(NULL), isoReceive
 	int busNr = 0;
 	int deviceNr = 0;
 	int currentConfig = -1;
-	const int desiredConfig = 1;
 
 	// parse device string, should look like "bus:device"
 	if (device.length() != 0) {
@@ -128,12 +127,12 @@ CUSBCommunication::CUSBCommunication(string device) : transfer(NULL), isoReceive
 	}
 
 	// configure the device, if necessary
-	if (currentConfig != desiredConfig) {
+	if (currentConfig != USB_DEVICE_TARGET_CONFIGURATION) {
 		COut::d("Updating USB configuration from " 
 			+ CFormat::intToString(currentConfig)
 			+ " to " 
-			+ CFormat::intToString(desiredConfig));	
-		ret = libusb_set_configuration(dev, desiredConfig);
+			+ CFormat::intToString(USB_DEVICE_TARGET_CONFIGURATION));	
+		ret = libusb_set_configuration(dev, USB_DEVICE_TARGET_CONFIGURATION);
 		if (ret != LIBUSB_SUCCESS) {
 			throw USBCommunicationException("Setting Configuration failed");
 		}

--- a/src/CUSBCommunication.h
+++ b/src/CUSBCommunication.h
@@ -25,6 +25,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "avrprog.h"
 #include "ExceptionBase.h"
 
+#define	USB_DEVICE_TARGET_CONFIGURATION (1)
+
 using namespace std;
 
 /**


### PR DESCRIPTION
This pull request aims to fix a bug where the board to be programmed has to be reset before programming it again (for example by power-cycleing it).

According to the libusb documentation [1], section "Configuration selection and handling", repeated configuration of a usb device can introduce drawbacks / problems. The documentation describes a possible solution to mentioned complications by  checking whether or not the configuration needs to be changed, which has been implemented here.

[1] http://libusb.sourceforge.net/api-1.0/caveats.html